### PR TITLE
Implementing fhir adapter for OpenMRS.

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -5386,6 +5386,12 @@
       "integrity": "sha512-M4Sjn6N/+O6/IXSJseKqHoFc+5FdGJ22sXqnjTpdZweHK64MzEPAyQZyEU3R/KRv2GLoa7nNtg/C2Ev6m7z+eA==",
       "dev": true
     },
+    "is-absolute-url": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/is-absolute-url/-/is-absolute-url-3.0.0.tgz",
+      "integrity": "sha512-3OkP8XrM2Xq4/IxsJnClfMp3OaM3TAatLPLKPeWcxLBTrpe6hihwtX+XZfJTcXg/FTRi4qjy0y/C5qiyNxY24g==",
+      "dev": true
+    },
     "is-accessor-descriptor": {
       "version": "0.1.6",
       "resolved": "https://registry.npmjs.org/is-accessor-descriptor/-/is-accessor-descriptor-0.1.6.tgz",
@@ -10185,9 +10191,9 @@
       }
     },
     "webpack-dev-server": {
-      "version": "3.7.2",
-      "resolved": "https://registry.npmjs.org/webpack-dev-server/-/webpack-dev-server-3.7.2.tgz",
-      "integrity": "sha512-mjWtrKJW2T9SsjJ4/dxDC2fkFVUw8jlpemDERqV0ZJIkjjjamR2AbQlr3oz+j4JLhYCHImHnXZK5H06P2wvUew==",
+      "version": "3.8.0",
+      "resolved": "https://registry.npmjs.org/webpack-dev-server/-/webpack-dev-server-3.8.0.tgz",
+      "integrity": "sha512-Hs8K9yI6pyMvGkaPTeTonhD6JXVsigXDApYk9JLW4M7viVBspQvb1WdAcWxqtmttxNW4zf2UFLsLNe0y87pIGQ==",
       "dev": true,
       "requires": {
         "ansi-html": "0.0.7",
@@ -10203,23 +10209,25 @@
         "import-local": "^2.0.0",
         "internal-ip": "^4.3.0",
         "ip": "^1.1.5",
+        "is-absolute-url": "^3.0.0",
         "killable": "^1.0.1",
         "loglevel": "^1.6.3",
         "opn": "^5.5.0",
         "p-retry": "^3.0.1",
-        "portfinder": "^1.0.20",
+        "portfinder": "^1.0.21",
         "schema-utils": "^1.0.0",
         "selfsigned": "^1.10.4",
-        "semver": "^6.1.1",
+        "semver": "^6.3.0",
         "serve-index": "^1.9.1",
         "sockjs": "0.3.19",
         "sockjs-client": "1.3.0",
-        "spdy": "^4.0.0",
+        "spdy": "^4.0.1",
         "strip-ansi": "^3.0.1",
         "supports-color": "^6.1.0",
         "url": "^0.11.0",
         "webpack-dev-middleware": "^3.7.0",
         "webpack-log": "^2.0.0",
+        "ws": "^6.2.1",
         "yargs": "12.0.5"
       },
       "dependencies": {
@@ -10329,6 +10337,15 @@
                 "strip-ansi": "^3.0.0"
               }
             }
+          }
+        },
+        "ws": {
+          "version": "6.2.1",
+          "resolved": "https://registry.npmjs.org/ws/-/ws-6.2.1.tgz",
+          "integrity": "sha512-GIyAXC2cB7LjvpgMt9EKS2ldqr0MTrORaleiOno6TweZ6r3TKtoFQWay/2PceJ3RuBasOHzXNn5Lrw1X0bEjqA==",
+          "dev": true,
+          "requires": {
+            "async-limiter": "~1.0.0"
           }
         },
         "yargs": {

--- a/package.json
+++ b/package.json
@@ -54,7 +54,7 @@
     "typescript": "^3.5.3",
     "webpack": "^4.39.1",
     "webpack-cli": "^3.3.6",
-    "webpack-dev-server": "^3.7.2"
+    "webpack-dev-server": "^3.8.0"
   },
   "dependencies": {
     "fhir.js": "0.0.20",

--- a/src/fhir.ts
+++ b/src/fhir.ts
@@ -1,4 +1,42 @@
-import fhirjs from "fhir.js";
+import makeFhir from "fhir.js/src/fhir.js";
+import { openmrsFetch, FetchHeaders, OpenmrsFetchError } from "./openmrs-fetch";
+
+const fhirConfig = {
+  // @ts-ignore
+  baseUrl: `/ws/fhir`
+};
+
+const openmrsFhirAdapter = {
+  http(requestObj: FHIRRequestObj) {
+    return openmrsFetch(requestObj.url, {
+      method: requestObj.method,
+      headers: requestObj.headers
+    }).then(
+      response => {
+        return {
+          status: response.status,
+          headers: response.headers,
+          data: response.body,
+          config: requestObj
+        };
+      },
+      (err: OpenmrsFetchError) => {
+        return {
+          status: err.response.status,
+          headers: err.response.headers,
+          data: err.response.body,
+          config: requestObj
+        };
+      }
+    );
+  }
+};
 
 // TODO
-export const fhir = null;
+export const fhir = makeFhir(fhirConfig, openmrsFhirAdapter);
+
+type FHIRRequestObj = {
+  url: string;
+  method: string;
+  headers: FetchHeaders;
+};

--- a/src/fhir.ts
+++ b/src/fhir.ts
@@ -2,7 +2,6 @@ import makeFhir from "fhir.js/src/fhir.js";
 import { openmrsFetch, FetchHeaders, OpenmrsFetchError } from "./openmrs-fetch";
 
 const fhirConfig = {
-  // @ts-ignore
   baseUrl: `/ws/fhir`
 };
 
@@ -32,7 +31,6 @@ const openmrsFhirAdapter = {
   }
 };
 
-// TODO
 export const fhir = makeFhir(fhirConfig, openmrsFhirAdapter);
 
 type FHIRRequestObj = {

--- a/src/fhir.ts
+++ b/src/fhir.ts
@@ -15,7 +15,7 @@ const openmrsFhirAdapter = {
         return {
           status: response.status,
           headers: response.headers,
-          data: response.body,
+          data: response.data,
           config: requestObj
         };
       },
@@ -23,7 +23,7 @@ const openmrsFhirAdapter = {
         return {
           status: err.response.status,
           headers: err.response.headers,
-          data: err.response.body,
+          data: err.responseBody,
           config: requestObj
         };
       }

--- a/src/openmrs-fetch.test.ts
+++ b/src/openmrs-fetch.test.ts
@@ -98,8 +98,9 @@ describe("openmrsFetch", () => {
       })
     );
 
-    return openmrsFetch("/ws/rest/v1/session").then(data => {
-      expect(data).toEqual({ value: "hi" });
+    return openmrsFetch("/ws/rest/v1/session").then(response => {
+      expect(response.status).toBe(200);
+      expect(response.data).toEqual({ value: "hi" });
     });
   });
 
@@ -113,8 +114,9 @@ describe("openmrsFetch", () => {
       })
     );
 
-    return openmrsFetch("/ws/rest/v1/session").then(data => {
-      expect(data).toEqual(null);
+    return openmrsFetch("/ws/rest/v1/session").then(response => {
+      expect(response.status).toBe(204);
+      expect(response.data).toEqual(null);
     });
   });
 

--- a/src/openmrs-fetch.test.ts
+++ b/src/openmrs-fetch.test.ts
@@ -146,6 +146,7 @@ describe("openmrsFetch", () => {
         );
         expect(err.message).toMatch(/\/ws\/rest\/v1\/session/);
         expect(err.responseBody).toEqual({ error: "The server is dead" });
+        expect(err.response.status).toBe(500);
       });
   });
 
@@ -170,6 +171,7 @@ describe("openmrsFetch", () => {
         );
         expect(err.message).toMatch(/\/ws\/rest\/v1\/session/);
         expect(err.responseBody).toEqual("a string response body");
+        expect(err.response.status).toBe(400);
       });
   });
 });

--- a/src/openmrs-fetch.ts
+++ b/src/openmrs-fetch.ts
@@ -72,8 +72,8 @@ export function openmrsFetch(
         return response;
       } else {
         // HTTP 200s - The request succeeded
-        return response.json().then(body => {
-          response.data = body;
+        return response.json().then(data => {
+          response.data = data;
           return response;
         });
       }

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -24,6 +24,7 @@ module.exports = {
   },
   plugins: [new CleanWebpackPlugin(), new ForkTsCheckerWebpackPlugin()],
   devServer: {
+    disableHostCheck: true,
     headers: {
       "Access-Control-Allow-Origin": "*"
     }


### PR DESCRIPTION
This PR finishes https://issues.openmrs.org/browse/MF-25. It uses https://github.com/FHIR/fhir.js, with a custom adapter that uses openmrsFetch.

Example usage:
```js
import { fhir } from '@openmrs/api'

fhir.read({
  type: 'Patient',
  id: 'dfhj4h5gfghj4hbvybnt5hgrydufcvf7yu',
}).then(response => {
  console.log(response.data)
})
```

![image (6)](https://user-images.githubusercontent.com/5524384/62956188-b54a9080-bdaf-11e9-86af-b177eecb9f99.png)