### PR TITLE
Using src types for typescript definitions

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1508,7 +1508,8 @@
     "Base64": {
       "version": "0.3.0",
       "resolved": "https://registry.npmjs.org/Base64/-/Base64-0.3.0.tgz",
-      "integrity": "sha1-baJhpOgNT6D1xoQlTlvM0Wu9zp8="
+      "integrity": "sha1-baJhpOgNT6D1xoQlTlvM0Wu9zp8=",
+      "dev": true
     },
     "abab": {
       "version": "2.0.0",
@@ -1714,6 +1715,7 @@
       "version": "0.1.11",
       "resolved": "https://registry.npmjs.org/asn1/-/asn1-0.1.11.tgz",
       "integrity": "sha1-VZvhg3bQik7E2+gId9J4GGObLfc=",
+      "dev": true,
       "optional": true
     },
     "asn1.js": {
@@ -1758,6 +1760,7 @@
       "version": "0.1.5",
       "resolved": "https://registry.npmjs.org/assert-plus/-/assert-plus-0.1.5.tgz",
       "integrity": "sha1-7nQAlBMALYTOxyGcasgRgS5yMWA=",
+      "dev": true,
       "optional": true
     },
     "assign-symbols": {
@@ -1806,6 +1809,7 @@
       "version": "0.5.0",
       "resolved": "https://registry.npmjs.org/aws-sign2/-/aws-sign2-0.5.0.tgz",
       "integrity": "sha1-xXED96F/wDfwLXwuZLYC6iI/fWM=",
+      "dev": true,
       "optional": true
     },
     "aws4": {
@@ -2054,6 +2058,7 @@
       "version": "0.9.5",
       "resolved": "https://registry.npmjs.org/bl/-/bl-0.9.5.tgz",
       "integrity": "sha1-wGt5evCF6gC8Unr8jvzxHeIjIFQ=",
+      "dev": true,
       "requires": {
         "readable-stream": "~1.0.26"
       },
@@ -2061,12 +2066,14 @@
         "isarray": {
           "version": "0.0.1",
           "resolved": "https://registry.npmjs.org/isarray/-/isarray-0.0.1.tgz",
-          "integrity": "sha1-ihis/Kmo9Bd+Cav8YDiTmwXR7t8="
+          "integrity": "sha1-ihis/Kmo9Bd+Cav8YDiTmwXR7t8=",
+          "dev": true
         },
         "readable-stream": {
           "version": "1.0.34",
           "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-1.0.34.tgz",
           "integrity": "sha1-Elgg40vIQtLyqq+v5MKRbuMsFXw=",
+          "dev": true,
           "requires": {
             "core-util-is": "~1.0.0",
             "inherits": "~2.0.1",
@@ -2077,7 +2084,8 @@
         "string_decoder": {
           "version": "0.10.31",
           "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-0.10.31.tgz",
-          "integrity": "sha1-YuIDvEF2bGwoyfyEMB2rHFMQ+pQ="
+          "integrity": "sha1-YuIDvEF2bGwoyfyEMB2rHFMQ+pQ=",
+          "dev": true
         }
       }
     },
@@ -2152,6 +2160,7 @@
       "version": "0.4.2",
       "resolved": "https://registry.npmjs.org/boom/-/boom-0.4.2.tgz",
       "integrity": "sha1-emNune1O/O+xnO9JR6PGffrukRs=",
+      "dev": true,
       "optional": true,
       "requires": {
         "hoek": "0.9.x"
@@ -2451,7 +2460,8 @@
     "caseless": {
       "version": "0.6.0",
       "resolved": "https://registry.npmjs.org/caseless/-/caseless-0.6.0.tgz",
-      "integrity": "sha1-gWfBq4OX+1u5X5bSjlqBxQ8kesQ="
+      "integrity": "sha1-gWfBq4OX+1u5X5bSjlqBxQ8kesQ=",
+      "dev": true
     },
     "chalk": {
       "version": "2.4.2",
@@ -2638,6 +2648,7 @@
       "version": "0.0.7",
       "resolved": "https://registry.npmjs.org/combined-stream/-/combined-stream-0.0.7.tgz",
       "integrity": "sha1-ATfmV7qlp1QcV6w3rF/AfXO03B8=",
+      "dev": true,
       "optional": true,
       "requires": {
         "delayed-stream": "0.0.5"
@@ -2818,7 +2829,8 @@
     "core-util-is": {
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/core-util-is/-/core-util-is-1.0.2.tgz",
-      "integrity": "sha1-tf1UIgqivFq1eqtxQMlAdUUDwac="
+      "integrity": "sha1-tf1UIgqivFq1eqtxQMlAdUUDwac=",
+      "dev": true
     },
     "cosmiconfig": {
       "version": "5.2.1",
@@ -2886,6 +2898,7 @@
       "version": "0.2.2",
       "resolved": "https://registry.npmjs.org/cryptiles/-/cryptiles-0.2.2.tgz",
       "integrity": "sha1-7ZH/HxetE9N0gohZT4pIoNJvMlw=",
+      "dev": true,
       "optional": true,
       "requires": {
         "boom": "0.4.x"
@@ -2929,6 +2942,7 @@
       "version": "0.5.3",
       "resolved": "https://registry.npmjs.org/ctype/-/ctype-0.5.3.tgz",
       "integrity": "sha1-gsGMJGH3QRTvFsE1IkrQuRRMoS8=",
+      "dev": true,
       "optional": true
     },
     "cyclist": {
@@ -3096,6 +3110,7 @@
       "version": "0.0.5",
       "resolved": "https://registry.npmjs.org/delayed-stream/-/delayed-stream-0.0.5.tgz",
       "integrity": "sha1-1LH0OpPoKW3+AmlPRoC8N6MTxz8=",
+      "dev": true,
       "optional": true
     },
     "depd": {
@@ -3949,6 +3964,7 @@
       "version": "0.0.20",
       "resolved": "https://registry.npmjs.org/fhir.js/-/fhir.js-0.0.20.tgz",
       "integrity": "sha1-c8iCZvsq6Pd0RFTXxxDOW2iIOZ8=",
+      "dev": true,
       "requires": {
         "Base64": "~0.3.0",
         "merge": "^1.1.3",
@@ -4123,7 +4139,8 @@
     "forever-agent": {
       "version": "0.5.2",
       "resolved": "https://registry.npmjs.org/forever-agent/-/forever-agent-0.5.2.tgz",
-      "integrity": "sha1-bQ4JxJIflKJ/Y9O0nF/v8epMUTA="
+      "integrity": "sha1-bQ4JxJIflKJ/Y9O0nF/v8epMUTA=",
+      "dev": true
     },
     "fork-ts-checker-webpack-plugin": {
       "version": "1.5.0",
@@ -4145,6 +4162,7 @@
       "version": "0.1.4",
       "resolved": "https://registry.npmjs.org/form-data/-/form-data-0.1.4.tgz",
       "integrity": "sha1-kavXiKupcCsaq/qLwBAxoqyeOxI=",
+      "dev": true,
       "optional": true,
       "requires": {
         "async": "~0.9.0",
@@ -4156,12 +4174,14 @@
           "version": "0.9.2",
           "resolved": "https://registry.npmjs.org/async/-/async-0.9.2.tgz",
           "integrity": "sha1-rqdNXmHB+JlhO/ZL2mbUx48v0X0=",
+          "dev": true,
           "optional": true
         },
         "mime": {
           "version": "1.2.11",
           "resolved": "https://registry.npmjs.org/mime/-/mime-1.2.11.tgz",
           "integrity": "sha1-WCA+7Ybjpe8XrtK32evUfwpg3RA=",
+          "dev": true,
           "optional": true
         }
       }
@@ -5056,6 +5076,7 @@
       "version": "1.1.1",
       "resolved": "https://registry.npmjs.org/hawk/-/hawk-1.1.1.tgz",
       "integrity": "sha1-h81JH5tG5OKurKM1QWdmiF0tHtk=",
+      "dev": true,
       "optional": true,
       "requires": {
         "boom": "0.4.x",
@@ -5079,6 +5100,7 @@
       "version": "0.9.1",
       "resolved": "https://registry.npmjs.org/hoek/-/hoek-0.9.1.tgz",
       "integrity": "sha1-PTIkYrrfB3Fup+uFuviAec3c5QU=",
+      "dev": true,
       "optional": true
     },
     "homedir-polyfill": {
@@ -5186,6 +5208,7 @@
       "version": "0.10.1",
       "resolved": "https://registry.npmjs.org/http-signature/-/http-signature-0.10.1.tgz",
       "integrity": "sha1-T72sEyVZqoMjEh5UB3nAoBKyfmY=",
+      "dev": true,
       "optional": true,
       "requires": {
         "asn1": "0.1.11",
@@ -5335,7 +5358,8 @@
     "inherits": {
       "version": "2.0.4",
       "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.4.tgz",
-      "integrity": "sha512-k/vGaX4/Yla3WzyMCvTQOXYeIHvqOKtnqBduzTHpzpQZzAskKMhZ2K+EnBiSM9zGSoIFeMpXKxa4dYeZIQqewQ=="
+      "integrity": "sha512-k/vGaX4/Yla3WzyMCvTQOXYeIHvqOKtnqBduzTHpzpQZzAskKMhZ2K+EnBiSM9zGSoIFeMpXKxa4dYeZIQqewQ==",
+      "dev": true
     },
     "ini": {
       "version": "1.3.5",
@@ -5450,7 +5474,8 @@
     "ip-regex": {
       "version": "2.1.0",
       "resolved": "https://registry.npmjs.org/ip-regex/-/ip-regex-2.1.0.tgz",
-      "integrity": "sha1-+ni/XS5pE8kRzp+BnuUUa7bYROk="
+      "integrity": "sha1-+ni/XS5pE8kRzp+BnuUUa7bYROk=",
+      "dev": true
     },
     "ipaddr.js": {
       "version": "1.9.0",
@@ -6760,7 +6785,8 @@
     "json-stringify-safe": {
       "version": "5.0.1",
       "resolved": "https://registry.npmjs.org/json-stringify-safe/-/json-stringify-safe-5.0.1.tgz",
-      "integrity": "sha1-Epai1Y/UXxmg9s4B1lcB4sc1tus="
+      "integrity": "sha1-Epai1Y/UXxmg9s4B1lcB4sc1tus=",
+      "dev": true
     },
     "json3": {
       "version": "3.3.3",
@@ -6919,7 +6945,8 @@
     "lodash-es": {
       "version": "4.17.15",
       "resolved": "https://registry.npmjs.org/lodash-es/-/lodash-es-4.17.15.tgz",
-      "integrity": "sha512-rlrc3yU3+JNOpZ9zj5pQtxnx2THmvRykwL4Xlxoa8I9lHBlVbbyPhgyPMioxVZ4NqyxaVVtaJnzsyOidQIhyyQ=="
+      "integrity": "sha512-rlrc3yU3+JNOpZ9zj5pQtxnx2THmvRykwL4Xlxoa8I9lHBlVbbyPhgyPMioxVZ4NqyxaVVtaJnzsyOidQIhyyQ==",
+      "dev": true
     },
     "lodash.sortby": {
       "version": "4.7.0",
@@ -7040,7 +7067,8 @@
     "merge": {
       "version": "1.2.1",
       "resolved": "https://registry.npmjs.org/merge/-/merge-1.2.1.tgz",
-      "integrity": "sha512-VjFo4P5Whtj4vsLzsYBu5ayHhoHJ0UqNm7ibvShmbmoz7tGi0vXaoJbGdB+GmDMLUdg8DpQXEIeVDAe8MaABvQ=="
+      "integrity": "sha512-VjFo4P5Whtj4vsLzsYBu5ayHhoHJ0UqNm7ibvShmbmoz7tGi0vXaoJbGdB+GmDMLUdg8DpQXEIeVDAe8MaABvQ==",
+      "dev": true
     },
     "merge-descriptors": {
       "version": "1.0.1",
@@ -7442,6 +7470,7 @@
       "version": "0.4.0",
       "resolved": "https://registry.npmjs.org/oauth-sign/-/oauth-sign-0.4.0.tgz",
       "integrity": "sha1-8ilW8x6nFRqCHl8vsywRPK2Ln2k=",
+      "dev": true,
       "optional": true
     },
     "object-assign": {
@@ -8207,7 +8236,8 @@
     "psl": {
       "version": "1.3.0",
       "resolved": "https://registry.npmjs.org/psl/-/psl-1.3.0.tgz",
-      "integrity": "sha512-avHdspHO+9rQTLbv1RO+MPYeP/SzsCoxofjVnHanETfQhTJrmB0HlDoW+EiN/R+C0BZ+gERab9NY0lPN2TxNag=="
+      "integrity": "sha512-avHdspHO+9rQTLbv1RO+MPYeP/SzsCoxofjVnHanETfQhTJrmB0HlDoW+EiN/R+C0BZ+gERab9NY0lPN2TxNag==",
+      "dev": true
     },
     "public-encrypt": {
       "version": "4.0.3",
@@ -8259,12 +8289,14 @@
     "punycode": {
       "version": "2.1.1",
       "resolved": "https://registry.npmjs.org/punycode/-/punycode-2.1.1.tgz",
-      "integrity": "sha512-XRsRjdf+j5ml+y/6GKHPZbrF/8p2Yga0JPtdqTIY2Xe5ohJPD9saDJJLPvp9+NSBprVvevdXZybnj2cv8OEd0A=="
+      "integrity": "sha512-XRsRjdf+j5ml+y/6GKHPZbrF/8p2Yga0JPtdqTIY2Xe5ohJPD9saDJJLPvp9+NSBprVvevdXZybnj2cv8OEd0A==",
+      "dev": true
     },
     "q": {
       "version": "1.5.1",
       "resolved": "https://registry.npmjs.org/q/-/q-1.5.1.tgz",
-      "integrity": "sha1-fjL3W0E4EpHQRhHxvxQQmsAGUdc="
+      "integrity": "sha1-fjL3W0E4EpHQRhHxvxQQmsAGUdc=",
+      "dev": true
     },
     "qs": {
       "version": "6.7.0",
@@ -8539,6 +8571,7 @@
       "version": "2.42.0",
       "resolved": "https://registry.npmjs.org/request/-/request-2.42.0.tgz",
       "integrity": "sha1-VyvQFIk4VkBArHqxSLlkI6BjMEo=",
+      "dev": true,
       "requires": {
         "aws-sign2": "~0.5.0",
         "bl": "~0.9.0",
@@ -8560,17 +8593,20 @@
         "mime-types": {
           "version": "1.0.2",
           "resolved": "https://registry.npmjs.org/mime-types/-/mime-types-1.0.2.tgz",
-          "integrity": "sha1-mVrhOSq4r/y/yyZB3QVOlDwNXc4="
+          "integrity": "sha1-mVrhOSq4r/y/yyZB3QVOlDwNXc4=",
+          "dev": true
         },
         "node-uuid": {
           "version": "1.4.8",
           "resolved": "https://registry.npmjs.org/node-uuid/-/node-uuid-1.4.8.tgz",
-          "integrity": "sha1-sEDrCSOWivq/jTL7HxfxFn/auQc="
+          "integrity": "sha1-sEDrCSOWivq/jTL7HxfxFn/auQc=",
+          "dev": true
         },
         "qs": {
           "version": "1.2.2",
           "resolved": "https://registry.npmjs.org/qs/-/qs-1.2.2.tgz",
-          "integrity": "sha1-GbV/8k3CqZzh+L32r82ln472H4g="
+          "integrity": "sha1-GbV/8k3CqZzh+L32r82ln472H4g=",
+          "dev": true
         }
       }
     },
@@ -9185,6 +9221,7 @@
       "version": "0.2.4",
       "resolved": "https://registry.npmjs.org/sntp/-/sntp-0.2.4.tgz",
       "integrity": "sha1-+4hfGLDzqtGJ+CSGJTa87ux1CQA=",
+      "dev": true,
       "optional": true,
       "requires": {
         "hoek": "0.9.x"
@@ -9559,6 +9596,7 @@
       "version": "0.0.6",
       "resolved": "https://registry.npmjs.org/stringstream/-/stringstream-0.0.6.tgz",
       "integrity": "sha512-87GEBAkegbBcweToUrdzf3eLhWNg06FJTebl4BVJz/JgWy8CvEr9dRtX5qWphiynMSQlxxi+QqN0z5T32SLlhA==",
+      "dev": true,
       "optional": true
     },
     "strip-ansi": {
@@ -9805,6 +9843,7 @@
       "version": "3.0.1",
       "resolved": "https://registry.npmjs.org/tough-cookie/-/tough-cookie-3.0.1.tgz",
       "integrity": "sha512-yQyJ0u4pZsv9D4clxO69OEjLWYw+jbgspjTue4lTQZLfV0c5l1VmK2y1JK8E9ahdpltPOaAThPcp5nKPUgSnsg==",
+      "dev": true,
       "optional": true,
       "requires": {
         "ip-regex": "^2.1.0",
@@ -9841,7 +9880,8 @@
     "tunnel-agent": {
       "version": "0.4.3",
       "resolved": "https://registry.npmjs.org/tunnel-agent/-/tunnel-agent-0.4.3.tgz",
-      "integrity": "sha1-Y3PbdpCf5XDgjXNYM2Xtgop07us="
+      "integrity": "sha1-Y3PbdpCf5XDgjXNYM2Xtgop07us=",
+      "dev": true
     },
     "tweetnacl": {
       "version": "0.14.5",

--- a/package.json
+++ b/package.json
@@ -3,13 +3,12 @@
   "version": "1.0.0",
   "description": "The javascript module for interacting with the OpenMRS API",
   "main": "dist/openmrs-esm-api.js",
-  "types": "dist/openmrs-esm-api.d.ts",
+  "types": "src/openmrs-esm-api.ts",
   "scripts": {
     "test": "jest",
     "start": "webpack-dev-server",
     "build": "webpack --mode=production",
     "typescript": "tsc",
-    "prepublishOnly": "tsc src/openmrs-esm-api.ts --jsx react --outFile dist/openmrs-esm-api.js --module system -d --moduleResolution node",
     "prettier": "prettier src/**/* --write",
     "lint": "eslint src --ext ts"
   },


### PR DESCRIPTION
https://github.com/openmrs/openmrs-esm-api/pull/10 doesn't work. If you install it into another package typescript fails for a variety of reasons.

I realized that just using the types we've defined in the source files is sufficient for us. We don't need to generate the `.d.ts` file at all, but can reuse the ones we already have.