### PR TITLE
Fixing problem with parsing patient uuid from url

### DIFF
--- a/src/shared-api-objects/current-patient.test.ts
+++ b/src/shared-api-objects/current-patient.test.ts
@@ -54,4 +54,29 @@ describe("current patient", () => {
         });
       });
   });
+
+  it("can handle dashes and alphanumeric characters in the patient uuid", () => {
+    fhir.read.mockReturnValueOnce(
+      Promise.resolve({
+        data: {}
+      })
+    );
+
+    window.history.pushState(
+      {},
+      document.title,
+      `/patient/34-asdsd-234243h342`
+    );
+    window.dispatchEvent(new CustomEvent("single-spa:routing-event"));
+
+    return getCurrentPatient()
+      .pipe(first())
+      .toPromise()
+      .then(() => {
+        expect(fhir.read).toHaveBeenCalledWith({
+          type: "Patient",
+          patient: "34-asdsd-234243h342"
+        });
+      });
+  });
 });

--- a/src/shared-api-objects/current-patient.test.ts
+++ b/src/shared-api-objects/current-patient.test.ts
@@ -1,0 +1,57 @@
+import { getCurrentPatient } from "./current-patient";
+import { fhir } from "../fhir";
+import { first } from "rxjs/operators";
+
+jest.mock("../fhir", () => ({
+  fhir: {
+    read: jest.fn()
+  }
+}));
+
+describe("current patient", () => {
+  beforeEach(() => {
+    fhir.read.mockReset();
+  });
+
+  it("fetches the correct patient from a patient chart URL", () => {
+    fhir.read.mockReturnValueOnce(
+      Promise.resolve({
+        data: {}
+      })
+    );
+
+    window.history.pushState({}, document.title, `/patient/12/chart`);
+    window.dispatchEvent(new CustomEvent("single-spa:routing-event"));
+
+    return getCurrentPatient()
+      .pipe(first())
+      .toPromise()
+      .then(() => {
+        expect(fhir.read).toHaveBeenCalledWith({
+          type: "Patient",
+          patient: "12"
+        });
+      });
+  });
+
+  it("fetches the correct patient from the patient home URL", () => {
+    fhir.read.mockReturnValueOnce(
+      Promise.resolve({
+        data: {}
+      })
+    );
+
+    window.history.pushState({}, document.title, `/patient/34`);
+    window.dispatchEvent(new CustomEvent("single-spa:routing-event"));
+
+    return getCurrentPatient()
+      .pipe(first())
+      .toPromise()
+      .then(() => {
+        expect(fhir.read).toHaveBeenCalledWith({
+          type: "Patient",
+          patient: "34"
+        });
+      });
+  });
+});

--- a/src/shared-api-objects/current-patient.ts
+++ b/src/shared-api-objects/current-patient.ts
@@ -37,12 +37,6 @@ export function refetchCurrentPatient() {
   );
 }
 
-// exported only for testing purposes. Should not be exported outside of openmrs-esm-api to other modules
-// The browser's url and routes are the only thing that should determine the current uuid.
-// export function setCurrentPatientUuid(uuid) {
-//   currentPatientUuid = uuid
-// }
-
 type PatientFhirOptions = {
   includeConfig: boolean;
 };

--- a/src/shared-api-objects/current-patient.ts
+++ b/src/shared-api-objects/current-patient.ts
@@ -17,7 +17,7 @@ window.addEventListener("single-spa:routing-event", () => {
 });
 
 function getPatientUuidFromUrl() {
-  const match = /\/patient\/(.+)\/?/.exec(location.pathname);
+  const match = /\/patient\/([a-zA-Z0-9]+)\/?/.exec(window.location.pathname);
   return match && match[1];
 }
 
@@ -36,6 +36,12 @@ export function refetchCurrentPatient() {
     fhir.read({ type: "Patient", patient: currentPatientUuid })
   );
 }
+
+// exported only for testing purposes. Should not be exported outside of openmrs-esm-api to other modules
+// The browser's url and routes are the only thing that should determine the current uuid.
+// export function setCurrentPatientUuid(uuid) {
+//   currentPatientUuid = uuid
+// }
 
 type PatientFhirOptions = {
   includeConfig: boolean;

--- a/src/shared-api-objects/current-patient.ts
+++ b/src/shared-api-objects/current-patient.ts
@@ -17,7 +17,7 @@ window.addEventListener("single-spa:routing-event", () => {
 });
 
 function getPatientUuidFromUrl() {
-  const match = /\/patient\/([a-zA-Z0-9]+)\/?/.exec(window.location.pathname);
+  const match = /\/patient\/([a-zA-Z0-9\-]+)\/?/.exec(location.pathname);
   return match && match[1];
 }
 


### PR DESCRIPTION
This fixes a bug where esm-api was incorrectly parsing the patient uuid from the url