### PR TITLE
Added ability to check if user has privilege or user is super user

### DIFF
--- a/src/shared-api-objects/current-user.ts
+++ b/src/shared-api-objects/current-user.ts
@@ -27,6 +27,15 @@ function getCurrentUser(
   ) as Observable<LoggedInUser | UnauthenticatedUser>;
 }
 
+function userHasPrivilege(requiredPrivilege, user) {
+  return user.privileges.find(p => requiredPrivilege === p.display);
+}
+
+function isSuperUser(user) {
+  const superUserRole = "System Developer";
+  return user.roles.find(role => role.display === superUserRole);
+}
+
 export { getCurrentUser };
 
 export function refetchCurrentUser() {
@@ -34,7 +43,10 @@ export function refetchCurrentUser() {
 }
 
 export function userHasAccess(requiredPrivilege, user) {
-  return user.privileges.find(p => requiredPrivilege === p.display);
+  if (userHasPrivilege(requiredPrivilege, user) || isSuperUser(user)) {
+    return true;
+  }
+  return false;
 }
 
 interface CurrentUserOptions {

--- a/src/shared-api-objects/user-has-access-react.component.tsx
+++ b/src/shared-api-objects/user-has-access-react.component.tsx
@@ -16,7 +16,7 @@ export default function UserHasAccessReact(props) {
   }, []);
 
   if (user) {
-    return userHasAccess(props.privilege, user) !== undefined && props.children;
+    return userHasAccess(props.privilege, user) && props.children;
   } else {
     return null;
   }


### PR DESCRIPTION
This PR is an attempt to fix a bug in UserHasAccess component. It tries to mimic https://github.com/openmrs/openmrs-core/blob/master/api/src/main/java/org/openmrs/User.java#L97 by doing the following

1.  checks if user has the required privilege  **or** the user has the in-built role `System Developer` (which makes him a super user), returns true
2. else returns false

See the discussion on https://github.com/openmrs/openmrs-esm-home/pull/15 for more description. 
The next steps for this PR would be to add the ability to pass in multiple privileges as props instead of one. cc @jonathandick @brandones @mseaton 