### PR TITLE
Rename fhirConfig.baseUrl to fhirBaseUrl

### DIFF
--- a/src/fhir.ts
+++ b/src/fhir.ts
@@ -1,9 +1,7 @@
 import makeFhir from "./fhirjs";
 import { openmrsFetch, FetchHeaders, OpenmrsFetchError } from "./openmrs-fetch";
 
-export const fhirConfig = {
-  baseUrl: `/ws/fhir2/R4`
-};
+export const fhirBaseUrl = `/ws/fhir2/R4`;
 
 const openmrsFhirAdapter = {
   http(requestObj: FHIRRequestObj) {
@@ -31,7 +29,7 @@ const openmrsFhirAdapter = {
   }
 };
 
-export const fhir = makeFhir(fhirConfig, openmrsFhirAdapter);
+export const fhir = makeFhir({ baseUrl: fhirBaseUrl }, openmrsFhirAdapter);
 
 type FHIRRequestObj = {
   url: string;

--- a/src/openmrs-esm-api.ts
+++ b/src/openmrs-esm-api.ts
@@ -20,7 +20,7 @@ defineConfigSchema("@openmrs/esm-api", {
 });
 
 export { openmrsFetch, openmrsObservableFetch } from "./openmrs-fetch";
-export { fhir, fhirConfig } from "./fhir";
+export { fhir, fhirBaseUrl } from "./fhir";
 export {
   getCurrentUser,
   refetchCurrentUser,


### PR DESCRIPTION
This is to reflect that the fhirBaseUrl is not actually configurable.

EDIT: **Wait** until dependent repos are updated before merging.